### PR TITLE
Fire callbacks even if there's an error

### DIFF
--- a/lib/pb-node.js
+++ b/lib/pb-node.js
@@ -1,3 +1,5 @@
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+
 var http = require('http');
 var fs = require('fs');
 var request = require('request');

--- a/lib/pb-node.js
+++ b/lib/pb-node.js
@@ -22,7 +22,6 @@ Pandorabot.prototype.listBots = function (callback) {
     url: protocol + '://' + this.host + path + qs
   };
   request.get(params, function (error, response, body) {
-    if (!error)
       callback(error, response, body);
   });
 };
@@ -36,7 +35,6 @@ Pandorabot.prototype.createBot = function (callback) {
     url: protocol + '://' + this.host + path + qs
   };
   request.put(params, function (error, response, body) {
-    if (!error)
       callback(error, response, body);
   });
 };
@@ -48,7 +46,6 @@ Pandorabot.prototype.deleteBot = function (callback) {
     url: protocol + '://' + this.host + path + qs
   };
   request.del(params, function (error, response, body) {
-    if (!error)
       callback(error, response, body);
   });
 };
@@ -94,7 +91,6 @@ Pandorabot.prototype.uploadFile = function (options, callback) {
     params.headers = { "Content-Length": stat.size };
     fs.createReadStream(options.filepath)
       .pipe(request.put(params, function (error, response, body) {
-        if (!error)
           callback(error, response, body);
       }));
   });
@@ -111,7 +107,6 @@ Pandorabot.prototype.deleteFile = function (options, callback) {
     url: protocol + '://' + this.host + path + qs
   };
   request.del(params, function (error, response, body) {
-    if (!error)
       callback(error, response, body);
   });
 };
@@ -123,7 +118,6 @@ Pandorabot.prototype.compileBot = function (callback) {
     url: protocol + '://' + this.host + path + qs
   };
   request.get(params, function (error, response, body) {
-    if (!error)
       callback(error, response, body);
   });
 };
@@ -136,7 +130,6 @@ Pandorabot.prototype.talk = function (options, callback) {
     url: protocol + '://' + this.host + path + qs
   };
   request.post(params, function(error, response, body) {
-    if (!error)
         callback(error, response, body);
   });
 };


### PR DESCRIPTION
If there's an error in the request, the callbacks aren't firing. Shouldn't they fire with the error as the first parameter?
